### PR TITLE
Allow searching for words with 'S', prevent breaking header HTML

### DIFF
--- a/github-wiki-search.user.js
+++ b/github-wiki-search.user.js
@@ -56,7 +56,9 @@ function userScript()
     }).blur(function() {
       if (jQuery.trim($(this).val()) === '') { $(this).css('color', '#999').val(msg); }
     });
-    highlightKeyword('#wiki-wrapper');
+    highlightKeyword('#wiki-content');
+    highlightKeyword('#results');
+    highlightKeyword('.instapaper_title');
   });
 
   // Keyword


### PR DESCRIPTION
Hi

Thanks for a great tool!
I've made a few small changes to the code to prevent the letter 's' being omitted from the search results and to prevent the markup being corrupted in the 'New Page' etc. buttons when the search term appears in the wiki page title.

Let me know if you'd like any additional info

Stuart
