### PR TITLE
Mention Opera support in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Browser
 - Chrome
 - Firefox - need [Greasemonkey](https://addons.mozilla.org/ja/firefox/addon/greasemonkey/)
 - Safari - need [NinjaKit](http://d.hatena.ne.jp/os0x/20100612/1276330696)
+- Opera - need `UserJavaScriptonHTTPS` enabled ([why and how] (http://www.opera.com/docs/userjs/using/#securepages))
 
 Install
 -------


### PR DESCRIPTION
Github apparently didn't like direct links to the setting in question, maybe because they'd be containing `I` and other nice chars, so instead link to the hopefully stable Opera resource. Benefit of also explaining what happens if this is enabled.
