### PR TITLE
Allow github enterprise URLs

### DIFF
--- a/github-wiki-search.user.js
+++ b/github-wiki-search.user.js
@@ -296,7 +296,7 @@
   };
 
   function allowedLocation(callback) {
-    if (/^https?:\/\/github\.com\/.*?\/.*?\/wiki/.test(location.href)) {
+    if (/^https?:\/\/github(\..*)?\.com\/.*?\/.*?\/wiki/.test(location.href)) {
       callback();
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
         "github-wiki-search.user.js"
       ],
       "matches": [
-        "https://github.com/*"
+        "https://github.com/*",
+        "https://github.ibm.com/*"
       ]
     }
   ]


### PR DESCRIPTION
Hey, I have added the possible to enable the plugin for urls such us `githut.*.com`. 

Additionally, I have added `github.ibm.com` into the manifest.json as a match. Let me know if you know a better way to do that more generic.

